### PR TITLE
Workflows Update

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -27,11 +27,11 @@ flag_management:
       paths:
         - "include"
         - "src"
-      after_n_builds: 1
+
     - name: python
       paths:
         - "src/mqt/**/*.py"
-      after_n_builds: 10
+
       statuses:
         - type: project
           threshold: 0.5%

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,11 +3,12 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@v1.0.1
 
 jobs:
   python-packaging:
     name: 🐍 Packaging
-    uses: cda-tum/mqt-core/.github/workflows/reusable-python-packaging.yml@v2.4.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@v1.0.1
 
   deploy:
     if: github.event_name == 'release' && github.event.action == 'published'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,40 +14,36 @@ concurrency:
 jobs:
   change-detection:
     name: 🔍 Change
-    uses: cda-tum/mqt-core/.github/workflows/reusable-change-detection.yml@v2.4.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-change-detection.yml@v1.0.1
 
   cpp-tests:
     name: 🇨‌ Test
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-tests)
-    uses: cda-tum/mqt-core/.github/workflows/reusable-cpp-ci.yml@v2.4.1
-    secrets:
-      token: ${{ secrets.CODECOV_TOKEN }}
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-ci.yml@v1.0.1
     with:
       cmake-args: ""
       cmake-args-ubuntu: -G Ninja
-      cmake-args-macos: -G Ninja
+      cmake-args-macos: -G Ninja -DMQT_CORE_WITH_GMP=ON
       cmake-args-windows: -T ClangCL
 
   cpp-linter:
     name: 🇨‌ Lint
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-linter)
-    uses: cda-tum/mqt-core/.github/workflows/reusable-cpp-linter.yml@v2.4.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-linter.yml@v1.0.1
 
   python-tests:
     name: 🐍 Test
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-python-tests)
-    uses: cda-tum/mqt-core/.github/workflows/reusable-python-ci.yml@v2.4.1
-    secrets:
-      token: ${{ secrets.CODECOV_TOKEN }}
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-ci.yml@v1.0.1
 
   code-ql:
     name: 📝 CodeQL
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-code-ql)
-    uses: cda-tum/mqt-core/.github/workflows/reusable-code-ql.yml@v2.4.1
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-code-ql.yml@v1.0.1
 
   required-checks-pass: # This job does nothing and is only used for branch protection
     name: 🚦 Check


### PR DESCRIPTION
__Description__

This PR switches the reusable workflows from MQT Core to the ones hosted at https://github.com/cda-tum/mqt-workflows. The reusable workflows used are the current latest versions. 
Furthermore, this PR adapts the configuration of the continuous deployment job so that the job is also triggered if the respective workflow file is updated. 

__Checklist__
- [x] The pull request only contains commits that are related to it.
