### PR TITLE
📌 Pin `scikit-build-core`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@
 [build-system]
 requires = [
     "nanobind~=2.13.0",
-    "scikit-build-core>=0.12.2",
+    "scikit-build-core~=0.12",
     "setuptools-scm>=9.2.2",
     "mqt.core~=3.6.0",
 ]
@@ -333,7 +333,7 @@ mqt-qudits = { workspace = true }
 [dependency-groups]
 build = [
     "nanobind~=2.13.0",
-    "scikit-build-core>=0.12.2",
+    "scikit-build-core~=0.12",
     "setuptools-scm>=9.2.2",
     "mqt.core~=3.6.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1821,7 +1821,7 @@ requires-dist = [
 build = [
     { name = "mqt-core", specifier = "~=3.6.0" },
     { name = "nanobind", specifier = "~=2.13.0" },
-    { name = "scikit-build-core", specifier = ">=0.12.2" },
+    { name = "scikit-build-core", specifier = "~=0.12" },
     { name = "setuptools-scm", specifier = ">=9.2.2" },
 ]
 dev = [
@@ -1835,7 +1835,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pytest-sugar", specifier = ">=1.1.1" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
-    { name = "scikit-build-core", specifier = ">=0.12.2" },
+    { name = "scikit-build-core", specifier = "~=0.12" },
     { name = "scipy", specifier = ">=1.10" },
     { name = "setuptools-scm", specifier = ">=9.2.2" },
     { name = "tensornetwork", specifier = ">=0.4" },


### PR DESCRIPTION
## Description

This PR pins `scikit-build-core` to `~=0.12` to prevent it from upgrading to version 1.0. The new version is incompatible with `nanobind.stubgen`. Once this issue is resolved, we can upgrade to 1.0 and benefit from the improved system for dynamic metadata. In particular, we should finally be able to drop our dependency on `setuptools-scm`.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.